### PR TITLE
Added a third (empty) parameter to the {{écouter}} template from the French Wiktionary

### DIFF
--- a/wikis/frwiktionary.py
+++ b/wikis/frwiktionary.py
@@ -16,7 +16,7 @@ SUMMARY = "Ajout d'un fichier audio de prononciation depuis Lingua Libre"
 
 # Do not remove the $1, it is used to force the section to have a content
 EMPTY_PRONUNCIATION_SECTION = "\n\n=== {{S|prononciation}} ===\n$1"
-PRONUNCIATION_LINE = "\n* {{écouter|lang=$2|$3|audio=$1}}"
+PRONUNCIATION_LINE = "\n* {{écouter|lang=$2|$3||audio=$1}}"
 
 # To be sure not to miss any title, they are normalized during comparaisons;
 # those listed bellow must thereby be in lower case and without any space


### PR DESCRIPTION
As suggested on Discord, I added an empty third positional parameter when using the `{{écouter}}` template from the French Wiktionary.

This is my first contribution to this bot and I'd like to reassert the existing code is duly documented and easily understandable. Good job!