### PR TITLE
Remove the {{ébauche-pron-audio|fr}} if there was one in frwikt

### DIFF
--- a/llbot.py
+++ b/llbot.py
@@ -16,8 +16,9 @@ from wikis.ocwiktionary import OcWiktionary
 from wikis.lexemes import Lexemes
 
 config = configparser.ConfigParser()
-config.read(os.path.dirname(os.path.realpath(__file__)) + "/config.ini")
-
+res=config.read(os.path.dirname(os.path.realpath(__file__)) + "/config.ini")
+if len(res) == 0:
+    raise OSError("config.ini does not exist")
 
 # Main
 def main():

--- a/llbot.py
+++ b/llbot.py
@@ -27,7 +27,9 @@ def main():
         "wikidatawiki": Wikidata(
             config.get("wiki", "user"), config.get("wiki", "password")
         ),
-        "lexemes": Lexemes(config.get("wiki", "user"), config.get("wiki", "password")),
+        "lexemes": Lexemes(
+            config.get("wiki", "user"), config.get("wiki", "password")
+        ),
         "frwiktionary": FrWiktionary(
             config.get("wiki", "user"), config.get("wiki", "password")
         ),

--- a/wikis/frwiktionary.py
+++ b/wikis/frwiktionary.py
@@ -289,6 +289,9 @@ class FrWiktionary:
             pronunciation_line,
         )
 
+        # Remove the {{ébauche-pron-audio|fr}} if there was one
+        section_content = re.sub("\*?\s*{{ébauche-pron-audio|fr}}\s*\n", "", section_content)
+
         wikicode.sections[1].contents = str(section_content)
 
         # Remove the ugly hack, see comment line 17

--- a/wikis/frwiktionary.py
+++ b/wikis/frwiktionary.py
@@ -19,7 +19,7 @@ EMPTY_PRONUNCIATION_SECTION = "\n\n=== {{S|prononciation}} ===\n$1"
 PRONUNCIATION_LINE = "\n* {{écouter|lang=$2|$3||audio=$1}}"
 
 # To be sure not to miss any title, they are normalized during comparaisons;
-# those listed bellow must thereby be in lower case and without any space
+# those listed below must thereby be in lower case and without any space
 FOLLOWING_SECTIONS = [
     "{{s|anagrammes}}",
     "{{s|anagr}}",


### PR DESCRIPTION
Remove the {{ébauche-pron-audio|fr}} if there was one in the "prononciation" section on the French Wiktionary.