### PR TITLE
Fix AttributeError: 'Namespace' object has no attribute 'func'

### DIFF
--- a/llbot.py
+++ b/llbot.py
@@ -103,7 +103,10 @@ def main():
             supported_wikis[dbname].set_dry_run()
 
     # Start the bot in the selected mode (simple or live)
-    items = args.func(args, supported_wikis)
+    try:
+        items = args.func(args, supported_wikis)
+    except AttributeError:
+        parser.error("\"simple\" or \"live\" is mandatory")
     print(len(items))
 
 


### PR DESCRIPTION
Check that "simple" or "live" are given. Otherwise exit llbot.py properly.
To reproduce the crash:
`python3 llbot.py --wiki frwiktionary --dryrun`