### PR TITLE
Fix TypeError: expected string or bytes-like object

### DIFF
--- a/wikis/frwiktionary.py
+++ b/wikis/frwiktionary.py
@@ -290,7 +290,7 @@ class FrWiktionary:
         )
 
         # Remove the {{ébauche-pron-audio|fr}} if there was one
-        section_content = re.sub("\*?\s*{{ébauche-pron-audio|fr}}\s*\n", "", section_content)
+        section_content = re.sub("\*?\s*{{ébauche-pron-audio|fr}}\s*\n", "", str(section_content))
 
         wikicode.sections[1].contents = str(section_content)
 


### PR DESCRIPTION
Fix Python crash:
```
  File "Lingua-Libre-Bot/wikis/frwiktionary.py", line 293, in append_file
    section_content = re.sub("\*?\s*{{ébauche-pron-audio|fr}}\s*\n", "", section_content)
  File "/usr/lib/python3.6/re.py", line 191, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: expected string or bytes-like object
```