### PR TITLE
Stopping properly with Ctrl+C

### DIFF
--- a/llbot.py
+++ b/llbot.py
@@ -110,4 +110,12 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        print('\nStopping Lingua Libre Bot')
+        try:
+            sys.exit(0)
+        except SystemExit:
+            os._exit(0)
+


### PR DESCRIPTION
Do not display the backtrace when stopping Lingua Libre Bot using Ctrl+C