### PR TITLE
Update frwiktionary.py

### DIFF
--- a/wikis/wiktionaries/frwiktionary.py
+++ b/wikis/wiktionaries/frwiktionary.py
@@ -222,9 +222,6 @@ class FrWiktionary(Wiktionary):
         pronunciation_line = PRONUNCIATION_LINE.replace("$1", filename).replace("$2", self.language_code_map[
             language_qid]).replace("$3", location).replace("$4", language_level)
 
-        if len(section_content.sections) > 1:
-            pronunciation_line += "\n\n"
-
         section_content.sections[0].contents = safe_append_text(
             section_content.sections[0].contents,
             pronunciation_line,


### PR DESCRIPTION
Hi! As reported [here](https://meta.wikimedia.org/wiki/User_talk:Lingua_Libre_Bot#Why_is_it_adding_additional_newlines_when_adding_audio_files?),  the bot seems to sometimes add two newlines when adding a new pronunciation to frwikt, resulting in blanks in the wiki pages.

As I understand it, it happens when the Prononciation section contains other information than just the audio recordings, i.e. subsections such as "Anagrammes", "Paronymes" etc. See here where it happened: [1](https://fr.wiktionary.org/w/index.php?title=carabinier&diff=prev&oldid=32930794), [2](https://fr.wiktionary.org/w/index.php?title=paladin&diff=prev&oldid=32930472), and here where it did not: [3](https://fr.wiktionary.org/w/index.php?title=franc-tireur&diff=prev&oldid=32930965), [4](https://fr.wiktionary.org/w/index.php?title=l%C3%A9gionnaire&diff=prev&oldid=32930795).

I suggest this quick fix, but we may need to look more into details for specific cases where it may be needed to add two newlines.

I don't have the proper setup to test the bot's stack. Could you take a look please?